### PR TITLE
Corrections for _index.md

### DIFF
--- a/site/content/documentation/_index.md
+++ b/site/content/documentation/_index.md
@@ -37,8 +37,8 @@ hide_page_title: "true"
 
 - <a href="/javadoc/latest">rdf4j API Javadoc</a>
 - <a href="/javadoc/3.0.0-M1">3.0.0-M1 Javadoc</a>
-- older releases: [<a href="/javadoc/2.4.0">2.4</a>], [<a href="/javadoc/2.3.0">2.3</a>] 
+- older release: <a href="/javadoc/2.5.4">2.5.4</a>
 
 # Project internal documentation
 
-- <a href="developer/">Developer workflow and project managemen</a>
+- <a href="developer/">Developer workflow and project management</a>


### PR DESCRIPTION
This PR addresses GitHub issue eclipse/rdf4j#1428

- Corrected typo
- Removed broken links to 2.4 and 2.3 doc
- Added link to 2.5.4 javadoc