### PR TITLE
Use img and add class

### DIFF
--- a/site/content/documentation/tools/server-workbench/index.md
+++ b/site/content/documentation/tools/server-workbench/index.md
@@ -391,7 +391,7 @@ Shapes need to be loaded into the following context:
 
     <http://rdf4j.org/schema/rdf4j#SHACLShapeGraph>
 
-![Loading shapes](images/loadShapes.png)
+<img src="images/loadShapes.png" alt="Loading shapes" class="img-responsive"/>
 
 This context is a hidden context that is only available through the following commands:
 
@@ -415,7 +415,7 @@ want to use is `1`, you can use the following URL to download your shapes as RDF
 All transactions are validated before being committed. A validation error when uploading data in
 the workbench looks like this:
 
-![Validation error](images/shaclValidationError.png)
+<img src="images/shaclValidationError.png" alt="Validation error" class="img-responsive"/>
 
 Your data will only be committed if it passes validation.
 


### PR DESCRIPTION
This fixes https://github.com/eclipse/rdf4j/issues/1589

* Use raw html instead of markdown (standard markdown does not seem to support classes) with img-responsive class