### PR TITLE
eclipse/rdf4j#2274 fix css layout so links are clickable on mobile

### DIFF
--- a/site/layouts/documentation/list.html
+++ b/site/layouts/documentation/list.html
@@ -3,7 +3,7 @@
     {{ if .Sections }}
       {{ range .Sections.ByWeight }}
       <div class="doc-section">
-      <h3 class="doc-section-header"><a href="{{ .Permalink | relURL }}">{{ .Title }}</a></h3>
+      <h4 class="doc-section-header"><a href="{{ .Permalink | relURL }}">{{ .Title }}</a></h4>
       <div class="doc-section-content">
         {{ .Content }}
           <ul>  

--- a/site/layouts/documentation/list.html
+++ b/site/layouts/documentation/list.html
@@ -3,15 +3,15 @@
     {{ if .Sections }}
       {{ range .Sections.ByWeight }}
       <div class="doc-section">
-        <div class="doc-section-header"><a href="{{ .Permalink | relURL }}">{{ .Title }}</a></div>
-        <div class="doc-section-content">
+      <h3 class="doc-section-header"><a href="{{ .Permalink | relURL }}">{{ .Title }}</a></h3>
+      <div class="doc-section-content">
         {{ .Content }}
           <ul>  
               {{ range .CurrentSection.Pages.ByWeight }}
               <li><a href="{{ .Permalink | relURL }}" title="{{ .Title }}">{{ .Title }}</a><br/></li>
               {{ end }}
           </ul>
-        </div>
+      </div>
       </div>
       {{ end }}
     {{else}}

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,1 +1,0 @@
-<link rel="stylesheet" href="/css/rdf4j.css">

--- a/site/layouts/partials/head_suffix.html
+++ b/site/layouts/partials/head_suffix.html
@@ -62,7 +62,7 @@
 {{ if ne .Page.Params.disable_css "true" }}
 {{- with .Site.Params.styles | default "https://eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/quicksilver.min.css" }}
 <link rel="stylesheet" href="{{ . | absURL }}">
-<link rel="stylesheet" href="css/rdf4j.css">
+<link rel="stylesheet" href="/css/rdf4j.css">
 {{- end }}
 {{- end }}
 {{- partial "google_tag_manager.html" . }}

--- a/site/static/css/rdf4j.css
+++ b/site/static/css/rdf4j.css
@@ -36,16 +36,15 @@ td,th {
 }
 
 div.doc-section {
-  float: left;
-  width: 400px;
-  margin: 10px;
 }
 
+h3.doc-section-header {
+  margin-bottom: 0px;
+}
 .doc-section-header a:link, .doc-section-header a:visited {
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
   font-weight: medium;
-  font-size: larger;
   background: #DA5800;
   padding-left: 20px;
   padding-right: 20px;
@@ -55,5 +54,5 @@ div.doc-section {
 .doc-section-content {
   background: white;
   padding: 6px;
-  box-shadow: 5px 5px 4px #888888;
+  box-shadow: 3px 3px 2px #888888;
 }

--- a/site/static/css/rdf4j.css
+++ b/site/static/css/rdf4j.css
@@ -36,6 +36,17 @@ td,th {
 }
 
 div.doc-section {
+  float: left;
+  width: 400px;
+  margin-left: 10px;
+}
+
+@media screen and (max-width: 600px) {
+  div.doc-section {
+    float: none;
+    width: 100%;
+    margin-left: 0px;
+  }
 }
 
 h4.doc-section-header {

--- a/site/static/css/rdf4j.css
+++ b/site/static/css/rdf4j.css
@@ -38,14 +38,17 @@ td,th {
 div.doc-section {
 }
 
-h3.doc-section-header {
+h4.doc-section-header {
+  margin-top: 20px;
   margin-bottom: 0px;
 }
+
 .doc-section-header a:link, .doc-section-header a:visited {
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
   font-weight: medium;
   background: #DA5800;
+  padding-top: 2px;
   padding-left: 20px;
   padding-right: 20px;
   color: black;


### PR DESCRIPTION
The culprit seems to have been the floating divs, though I still don't quite see _why_. It means we loose the two columns of these sections on the regular web view, but at least it all works now AFAICT.

Normal web view now looks like this:

![Screenshot from 2020-05-27 09-34-36](https://user-images.githubusercontent.com/728776/82960269-4fa55900-9ffd-11ea-8487-f6a0c1a566f3.png)

Mobile view looks same as it did before, except the links can now be clicked. 

I also took the opportunity for some minor, semi-related cleanups (including removing a duplicate stylesheet import). 